### PR TITLE
Change signature to accept a Signer

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ require 'jwt'
 payload = { data: 'test' }
 
 # IMPORTANT: set nil as password parameter
-token = JWT.encode payload, nil, 'none'
+token = JWT.encode payload: payload, signer: JWT::Signer.new(nil, 'none')
 
 # eyJhbGciOiJub25lIn0.eyJkYXRhIjoidGVzdCJ9.
 puts token
@@ -79,7 +79,7 @@ puts decoded_token
 # The secret must be a string. A JWT::DecodeError will be raised if it isn't provided.
 hmac_secret = 'my$ecretK3y'
 
-token = JWT.encode payload, hmac_secret, 'HS256'
+token = JWT.encode payload: payload, signer: JWT::Signer.new(hmac_secret, 'HS256')
 
 # eyJhbGciOiJIUzI1NiJ9.eyJkYXRhIjoidGVzdCJ9.pNIWIL34Jo13LViZAJACzK6Yf0qnvT_BuwOxiMCPE-Y
 puts token
@@ -110,7 +110,7 @@ on MacOS with `brew install libsodium`.
 rsa_private = OpenSSL::PKey::RSA.generate 2048
 rsa_public = rsa_private.public_key
 
-token = JWT.encode payload, rsa_private, 'RS256'
+token = JWT.encode payload: payload, signer: JWT::Signer.new(rsa_private, 'RS256')
 
 # eyJhbGciOiJSUzI1NiJ9.eyJkYXRhIjoidGVzdCJ9.GplO4w1spRgvEJQ3-FOtZr-uC8L45Jt7SN0J4woBnEXG_OZBSNcZjAJWpjadVYEe2ev3oUBFDYM1N_-0BTVeFGGYvMewu8E6aMjSZvOpf1cZBew-Vt4poSq7goG2YRI_zNPt3af2lkPqXD796IKC5URrEvcgF5xFQ-6h07XRDpSRx1ECrNsUOt7UM3l1IB4doY11GzwQA5sHDTmUZ0-kBT76ZMf12Srg_N3hZwphxBtudYtN5VGZn420sVrQMdPE_7Ni3EiWT88j7WCr1xrF60l8sZT3yKCVleG7D2BEXacTntB7GktBv4Xo8OKnpwpqTpIlC05dMowMkz3rEAAYbQ
 puts token
@@ -137,7 +137,7 @@ ecdsa_key.generate_key
 ecdsa_public = OpenSSL::PKey::EC.new ecdsa_key
 ecdsa_public.private_key = nil
 
-token = JWT.encode payload, ecdsa_key, 'ES256'
+token = JWT.encode payload: payload, signer: JWT::Signer.new(ecdsa_key, 'ES256')
 
 # eyJhbGciOiJFUzI1NiJ9.eyJkYXRhIjoidGVzdCJ9.AlLW--kaF7EX1NMX9WJRuIW8NeRJbn2BLXHns7Q5TZr7Hy3lF6MOpMlp7GoxBFRLISQ6KrD0CJOrR8aogEsPeg
 puts token
@@ -167,7 +167,7 @@ For more detailed installation instruction check the official [repository](https
 ```ruby
 private_key = RbNaCl::Signatures::Ed25519::SigningKey.new('abcdefghijklmnopqrstuvwxyzABCDEF')
 public_key = private_key.verify_key
-token = JWT.encode payload, private_key, 'ED25519'
+token = JWT.encode payload: payload, signer: JWT::Signer.new(private_key, 'ED25519')
 
 # eyJhbGciOiJFRDI1NTE5In0.eyJkYXRhIjoidGVzdCJ9.6xIztXyOupskddGA_RvKU76V9b2dCQUYhoZEVFnRimJoPYIzZ2Fm47CWw8k2NTCNpgfAuxg9OXjaiVK7MvrbCQ
 puts token
@@ -197,7 +197,7 @@ gem 'openssl', '~> 2.1'
 rsa_private = OpenSSL::PKey::RSA.generate 2048
 rsa_public = rsa_private.public_key
 
-token = JWT.encode payload, rsa_private, 'PS256'
+token = JWT.encode payload: payload, signer: JWT::Signer.new(rsa_private, 'PS256')
 
 # eyJhbGciOiJQUzI1NiJ9.eyJkYXRhIjoidGVzdCJ9.KEmqagMUHM-NcmXo6818ZazVTIAkn9qU9KQFT1c5Iq91n0KRpAI84jj4ZCdkysDlWokFs3Dmn4MhcXP03oJKLFgnoPL40_Wgg9iFr0jnIVvnMUp1kp2RFUbL0jqExGTRA3LdAhuvw6ZByGD1bkcWjDXygjQw-hxILrT1bENjdr0JhFd-cB0-ps5SB0mwhFNcUw-OM3Uu30B1-mlFaelUY8jHJYKwLTZPNxHzndt8RGXF8iZLp7dGb06HSCKMcVzhASGMH4ZdFystRe2hh31cwcvnl-Eo_D4cdwmpN3Abhk_8rkxawQJR3duh8HNKc4AyFPo7SabEaSu2gLnLfN3yfg
 puts token
@@ -229,7 +229,7 @@ Ruby-jwt gem supports custom [header fields](https://tools.ietf.org/html/rfc7519
 To add custom header fields you need to pass `header_fields` parameter
 
 ```ruby
-token = JWT.encode payload, key, algorithm='HS256', header_fields={}
+token = JWT.encode payload: payload, signer: JWT::Signer.new(key, algorithm='HS256'), header_fields={}
 ```
 
 **Example:**
@@ -240,7 +240,7 @@ require 'jwt'
 payload = { data: 'test' }
 
 # IMPORTANT: set nil as password parameter
-token = JWT.encode payload, nil, 'none', { typ: 'JWT' }
+token = JWT.encode payload: payload, signer: JWT::Signer.new(nil, 'none'), { typ: 'JWT' }
 
 # eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.eyJkYXRhIjoidGVzdCJ9.
 puts token
@@ -268,7 +268,7 @@ From [Oauth JSON Web Token 4.1.4. "exp" (Expiration Time) Claim](https://tools.i
 exp = Time.now.to_i + 4 * 3600
 exp_payload = { data: 'data', exp: exp }
 
-token = JWT.encode exp_payload, hmac_secret, 'HS256'
+token = JWT.encode payload: exp_payload, signer: JWT::Signer.new(hmac_secret, 'HS256')
 
 begin
   decoded_token = JWT.decode token, hmac_secret, true, { algorithm: 'HS256' }
@@ -292,7 +292,7 @@ leeway = 30 # seconds
 exp_payload = { data: 'data', exp: exp }
 
 # build expired token
-token = JWT.encode exp_payload, hmac_secret, 'HS256'
+token = JWT.encode payload: exp_payload, signer: JWT::Signer.new(hmac_secret, 'HS256')
 
 begin
   # add leeway to ensure the token is still accepted
@@ -314,7 +314,7 @@ From [Oauth JSON Web Token 4.1.5. "nbf" (Not Before) Claim](https://tools.ietf.o
 nbf = Time.now.to_i - 3600
 nbf_payload = { data: 'data', nbf: nbf }
 
-token = JWT.encode nbf_payload, hmac_secret, 'HS256'
+token = JWT.encode payload: nbf_payload, signer: JWT::Signer.new(hmac_secret, 'HS256')
 
 begin
   decoded_token = JWT.decode token, hmac_secret, true, { algorithm: 'HS256' }
@@ -338,7 +338,7 @@ leeway = 30
 nbf_payload = { data: 'data', nbf: nbf }
 
 # build expired token
-token = JWT.encode nbf_payload, hmac_secret, 'HS256'
+token = JWT.encode payload: nbf_payload, signer: JWT::Signer.new(hmac_secret, 'HS256')
 
 begin
   # add leeway to ensure the token is valid
@@ -360,7 +360,7 @@ You can pass multiple allowed issuers as an Array, verification will pass if one
 iss = 'My Awesome Company Inc. or https://my.awesome.website/'
 iss_payload = { data: 'data', iss: iss }
 
-token = JWT.encode iss_payload, hmac_secret, 'HS256'
+token = JWT.encode payload: iss_payload, signer: JWT::Signer.new(hmac_secret, 'HS256')
 
 begin
   # Add iss to the validation to check if the token has been manipulated
@@ -380,7 +380,7 @@ From [Oauth JSON Web Token 4.1.3. "aud" (Audience) Claim](https://tools.ietf.org
 aud = ['Young', 'Old']
 aud_payload = { data: 'data', aud: aud }
 
-token = JWT.encode aud_payload, hmac_secret, 'HS256'
+token = JWT.encode payload: aud_payload, signer: JWT::Signer.new(hmac_secret, 'HS256')
 
 begin
   # Add aud to the validation to check if the token has been manipulated
@@ -403,7 +403,7 @@ jti_raw = [hmac_secret, iat].join(':').to_s
 jti = Digest::MD5.hexdigest(jti_raw)
 jti_payload = { data: 'data', iat: iat, jti: jti }
 
-token = JWT.encode jti_payload, hmac_secret, 'HS256'
+token = JWT.encode payload: jti_payload, signer: JWT::Signer.new(hmac_secret, 'HS256')
 
 begin
   # If :verify_jti is true, validation will pass if a JTI is present
@@ -430,7 +430,7 @@ From [Oauth JSON Web Token 4.1.6. "iat" (Issued At) Claim](https://tools.ietf.or
 iat = Time.now.to_i
 iat_payload = { data: 'data', iat: iat }
 
-token = JWT.encode iat_payload, hmac_secret, 'HS256'
+token = JWT.encode payload: iat_payload, signer: JWT::Signer.new(hmac_secret, 'HS256')
 
 begin
   # Add iat to the validation to check if the token has been manipulated
@@ -450,7 +450,7 @@ From [Oauth JSON Web Token 4.1.2. "sub" (Subject) Claim](https://tools.ietf.org/
 sub = 'Subject'
 sub_payload = { data: 'data', sub: sub }
 
-token = JWT.encode sub_payload, hmac_secret, 'HS256'
+token = JWT.encode payload: sub_payload, signer: JWT::Signer.new(hmac_secret, 'HS256')
 
 begin
   # Add sub to the validation to check if the token has been manipulated
@@ -470,7 +470,7 @@ iss_payload = { data: 'data', iss: issuers.first }
 
 secrets = { issuers.first => hmac_secret, issuers.last => 'hmac_secret2' }
 
-token = JWT.encode iss_payload, hmac_secret, 'HS256'
+token = JWT.encode payload: iss_payload, signer: JWT::Signer.new(hmac_secret, 'HS256')
 
 begin
   # Add iss to the validation to check if the token has been manipulated
@@ -519,7 +519,7 @@ JWK is a JSON structure representing a cryptographic key. Currently only support
 jwk = JWT::JWK.new(OpenSSL::PKey::RSA.new(2048), "optional-kid")
 payload, headers = { data: 'data' }, { kid: jwk.kid }
 
-token = JWT.encode(payload, jwk.keypair, 'RS512', headers)
+token = JWT.encode(payload: payload, signer: JWT::Signer.new(jwk.keypair, 'RS512'), header_fields: headers)
 
 # The jwk loader would fetch the set of JWKs from a trusted source
 jwk_loader = ->(options) do

--- a/lib/jwt.rb
+++ b/lib/jwt.rb
@@ -7,6 +7,7 @@ require 'jwt/default_options'
 require 'jwt/encode'
 require 'jwt/error'
 require 'jwt/jwk'
+require 'jwt/signer'
 
 # JSON Web Token implementation
 #
@@ -15,16 +16,21 @@ require 'jwt/jwk'
 module JWT
   include JWT::DefaultOptions
 
-  module_function
-
-  def encode(payload, key, algorithm = 'HS256', header_fields = {})
-    Encode.new(payload: payload,
-               key: key,
-               algorithm: algorithm,
-               headers: header_fields).segments
+  def self.encode(payload:, header_fields: {}, signer: nil)
+    Encode.new(
+      payload: payload,
+      headers: header_fields,
+      signer: signer
+    ).segments
   end
 
-  def decode(jwt, key = nil, verify = true, options = {}, &keyfinder)
-    Decode.new(jwt, key, verify, DEFAULT_OPTIONS.merge(options), &keyfinder).decode_segments
+  def self.decode(jwt, key = nil, verify = true, options = {}, &keyfinder)
+    Decode.new(
+      jwt,
+      key,
+      verify,
+      DEFAULT_OPTIONS.merge(options),
+      &keyfinder
+    ).decode_segments
   end
 end

--- a/lib/jwt/algos/hmac.rb
+++ b/lib/jwt/algos/hmac.rb
@@ -26,7 +26,10 @@ module JWT
             false
           end
         else
-          SecurityUtils.secure_compare(signature, sign(JWT::Signature::ToSign.new(algorithm, signing_input, public_key)))
+          SecurityUtils.secure_compare(
+            signature,
+            sign(JWT::Signer::ToSign.new(algorithm, signing_input, public_key))
+          )
         end
       end
     end

--- a/lib/jwt/signature.rb
+++ b/lib/jwt/signature.rb
@@ -14,13 +14,7 @@ module JWT
   # Signature logic for JWT
   module Signature
     extend self
-    ToSign = Struct.new(:algorithm, :msg, :key)
     ToVerify = Struct.new(:algorithm, :public_key, :signing_input, :signature)
-
-    def sign(algorithm, msg, key)
-      algo, code = Algos.find(algorithm)
-      algo.sign ToSign.new(code, msg, key)
-    end
 
     def verify(algorithm, key, signing_input, signature)
       algo, code = Algos.find(algorithm)

--- a/lib/jwt/signer.rb
+++ b/lib/jwt/signer.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+#
+module JWT
+  class Signer
+    ToSign = Struct.new(:algorithm, :msg, :key)
+
+    def initialize(key, algorithm = 'HS256')
+      @key = key
+      @algo, @code = Algos.find(algorithm)
+    end
+
+    def algorithm
+      @code
+    end
+
+    def sign(msg)
+      @algo.sign ToSign.new(@code, msg, @key)
+    end
+  end
+end

--- a/spec/integration/readme_examples_spec.rb
+++ b/spec/integration/readme_examples_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe 'README.md code test' do
     let(:payload) { { data: 'test' } }
 
     it 'NONE' do
-      token = JWT.encode payload, nil, 'none'
+      token = JWT.encode payload: payload, signer: JWT::Signer.new(nil, 'none')
       decoded_token = JWT.decode token, nil, false
 
       expect(token).to eq 'eyJhbGciOiJub25lIn0.eyJkYXRhIjoidGVzdCJ9.'
@@ -16,7 +16,7 @@ RSpec.describe 'README.md code test' do
     end
 
     it 'decodes with HMAC algorithm with secret key' do
-      token = JWT.encode payload, 'my$ecretK3y', 'HS256'
+      token = JWT.encode payload: payload, signer: JWT::Signer.new('my$ecretK3y', 'HS256')
       decoded_token = JWT.decode token, 'my$ecretK3y', false
 
       expect(token).to eq 'eyJhbGciOiJIUzI1NiJ9.eyJkYXRhIjoidGVzdCJ9.pNIWIL34Jo13LViZAJACzK6Yf0qnvT_BuwOxiMCPE-Y'
@@ -27,7 +27,7 @@ RSpec.describe 'README.md code test' do
     end
 
     it 'decodes with HMAC algorithm without secret key' do
-      token = JWT.encode payload, nil, 'HS256'
+      token = JWT.encode payload: payload, signer: JWT::Signer.new(nil, 'HS256')
       decoded_token = JWT.decode token, nil, false
 
       expect(token).to eq 'eyJhbGciOiJIUzI1NiJ9.eyJkYXRhIjoidGVzdCJ9.pVzcY2dX8JNM3LzIYeP2B1e1Wcpt1K3TWVvIYSF4x-o'
@@ -41,7 +41,7 @@ RSpec.describe 'README.md code test' do
       rsa_private = OpenSSL::PKey::RSA.generate 2048
       rsa_public = rsa_private.public_key
 
-      token = JWT.encode payload, rsa_private, 'RS256'
+      token = JWT.encode payload: payload, signer: JWT::Signer.new(rsa_private, 'RS256')
       decoded_token = JWT.decode token, rsa_public, true, algorithm: 'RS256'
 
       expect(decoded_token).to eq [
@@ -56,7 +56,7 @@ RSpec.describe 'README.md code test' do
       ecdsa_public = OpenSSL::PKey::EC.new ecdsa_key
       ecdsa_public.private_key = nil
 
-      token = JWT.encode payload, ecdsa_key, 'ES256'
+      token = JWT.encode payload: payload, signer: JWT::Signer.new(ecdsa_key, 'ES256')
       decoded_token = JWT.decode token, ecdsa_public, true, algorithm: 'ES256'
 
       expect(decoded_token).to eq [
@@ -70,7 +70,7 @@ RSpec.describe 'README.md code test' do
         rsa_private = OpenSSL::PKey::RSA.generate 2048
         rsa_public = rsa_private.public_key
 
-        token = JWT.encode payload, rsa_private, 'PS256'
+        token = JWT.encode payload: payload, signer: JWT::Signer.new(rsa_private, 'PS256')
         decoded_token = JWT.decode token, rsa_public, true, algorithm: 'PS256'
 
         expect(decoded_token).to eq [
@@ -89,7 +89,7 @@ RSpec.describe 'README.md code test' do
         exp = Time.now.to_i + (4 * 3600)
         exp_payload = { data: 'data', exp: exp }
 
-        token = JWT.encode exp_payload, hmac_secret, 'HS256'
+        token = JWT.encode payload: exp_payload, signer: JWT::Signer.new(hmac_secret, 'HS256')
 
         expect do
           JWT.decode token, hmac_secret, true, algorithm: 'HS256'
@@ -102,7 +102,7 @@ RSpec.describe 'README.md code test' do
 
         exp_payload = { data: 'data', exp: exp }
 
-        token = JWT.encode exp_payload, hmac_secret, 'HS256'
+        token = JWT.encode payload: exp_payload, signer: JWT::Signer.new(hmac_secret, 'HS256')
 
         expect do
           JWT.decode token, hmac_secret, true, leeway: leeway, algorithm: 'HS256'
@@ -114,7 +114,7 @@ RSpec.describe 'README.md code test' do
       it 'without leeway' do
         nbf = Time.now.to_i - 3600
         nbf_payload = { data: 'data', nbf: nbf }
-        token = JWT.encode nbf_payload, hmac_secret, 'HS256'
+        token = JWT.encode payload: nbf_payload, signer: JWT::Signer.new(hmac_secret, 'HS256')
 
         expect do
           JWT.decode token, hmac_secret, true, algorithm: 'HS256'
@@ -125,7 +125,7 @@ RSpec.describe 'README.md code test' do
         nbf = Time.now.to_i + 10
         leeway = 30
         nbf_payload = { data: 'data', nbf: nbf }
-        token = JWT.encode nbf_payload, hmac_secret, 'HS256'
+        token = JWT.encode payload: nbf_payload, signer: JWT::Signer.new(hmac_secret, 'HS256')
 
         expect do
           JWT.decode token, hmac_secret, true, leeway: leeway, algorithm: 'HS256'
@@ -137,7 +137,7 @@ RSpec.describe 'README.md code test' do
       iss = 'My Awesome Company Inc. or https://my.awesome.website/'
       iss_payload = { data: 'data', iss: iss }
 
-      token = JWT.encode iss_payload, hmac_secret, 'HS256'
+      token = JWT.encode payload: iss_payload, signer: JWT::Signer.new(hmac_secret, 'HS256')
 
       expect do
         JWT.decode token, hmac_secret, true, iss: iss, algorithm: 'HS256'
@@ -149,7 +149,7 @@ RSpec.describe 'README.md code test' do
         aud = %w[Young Old]
         aud_payload = { data: 'data', aud: aud }
 
-        token = JWT.encode aud_payload, hmac_secret, 'HS256'
+        token = JWT.encode payload: aud_payload, signer: JWT::Signer.new(hmac_secret, 'HS256')
 
         expect do
           JWT.decode token, hmac_secret, true, aud: %w[Old Young], verify_aud: true, algorithm: 'HS256'
@@ -160,7 +160,7 @@ RSpec.describe 'README.md code test' do
         aud = 'Kids'
         aud_payload = { data: 'data', aud: aud }
 
-        token = JWT.encode aud_payload, hmac_secret, 'HS256'
+        token = JWT.encode payload: aud_payload, signer: JWT::Signer.new(hmac_secret, 'HS256')
 
         expect do
           JWT.decode token, hmac_secret, true, aud: 'Kids', verify_aud: true, algorithm: 'HS256'
@@ -175,7 +175,7 @@ RSpec.describe 'README.md code test' do
       jti = Digest::MD5.hexdigest(jti_raw)
       jti_payload = { data: 'data', iat: iat, jti: jti }
 
-      token = JWT.encode jti_payload, hmac_secret, 'HS256'
+      token = JWT.encode payload: jti_payload, signer: JWT::Signer.new(hmac_secret, 'HS256')
 
       expect do
         JWT.decode token, hmac_secret, true, verify_jti: true, algorithm: 'HS256'
@@ -187,7 +187,7 @@ RSpec.describe 'README.md code test' do
         iat = Time.now.to_i
         iat_payload = { data: 'data', iat: iat }
 
-        token = JWT.encode iat_payload, hmac_secret, 'HS256'
+        token = JWT.encode payload: iat_payload, signer: JWT::Signer.new(hmac_secret, 'HS256')
 
         expect do
           JWT.decode token, hmac_secret, true, verify_iat: true, algorithm: 'HS256'
@@ -198,7 +198,7 @@ RSpec.describe 'README.md code test' do
         iat = Time.now.to_i - 7
         iat_payload = { data: 'data', iat: iat, leeway: 10 }
 
-        token = JWT.encode iat_payload, hmac_secret, 'HS256'
+        token = JWT.encode payload: iat_payload, signer: JWT::Signer.new(hmac_secret, 'HS256')
 
         expect do
           JWT.decode token, hmac_secret, true, verify_iat: true, algorithm: 'HS256'
@@ -210,7 +210,11 @@ RSpec.describe 'README.md code test' do
       it 'with custom field' do
         payload = { data: 'test' }
 
-        token = JWT.encode payload, nil, 'none', typ: 'JWT'
+        token = JWT.encode(
+          payload: payload,
+          signer: JWT::Signer.new(nil, 'none'),
+          header_fields: { typ: 'JWT' }
+        )
         _, header = JWT.decode token, nil, false
 
         expect(header['typ']).to eq 'JWT'
@@ -221,7 +225,7 @@ RSpec.describe 'README.md code test' do
       sub = 'Subject'
       sub_payload = { data: 'data', sub: sub }
 
-      token = JWT.encode sub_payload, hmac_secret, 'HS256'
+      token = JWT.encode payload: sub_payload, signer: JWT::Signer.new(hmac_secret, 'HS256')
 
       expect do
         JWT.decode token, hmac_secret, true, 'sub' => sub, :verify_sub => true, :algorithm => 'HS256'
@@ -231,7 +235,7 @@ RSpec.describe 'README.md code test' do
     it 'required_claims' do
       payload = { data: 'test' }
 
-      token = JWT.encode payload, hmac_secret, 'HS256'
+      token = JWT.encode payload: payload, signer: JWT::Signer.new(hmac_secret, 'HS256')
 
       expect do
         JWT.decode token, hmac_secret, true, required_claims: ['exp'], algorithm: 'HS256'
@@ -248,7 +252,7 @@ RSpec.describe 'README.md code test' do
 
       secrets = { issuers.first => hmac_secret, issuers.last => 'hmac_secret2' }
 
-      token = JWT.encode iss_payload, hmac_secret, 'HS256'
+      token = JWT.encode payload: iss_payload, signer: JWT::Signer.new(hmac_secret, 'HS256')
 
       expect do
         # Add iss to the validation to check if the token has been manipulated
@@ -263,7 +267,11 @@ RSpec.describe 'README.md code test' do
       payload = { data: 'data' }
       headers = { kid: jwk.kid }
 
-      token = JWT.encode(payload, jwk.keypair, 'RS512', headers)
+      token = JWT.encode(
+        payload: payload,
+        signer: JWT::Signer.new(jwk.keypair, 'RS512'),
+        header_fields: headers
+      )
 
       # The jwk loader would fetch the set of JWKs from a trusted source
       jwk_loader = ->(options) do

--- a/spec/jwk/decode_with_jwk_spec.rb
+++ b/spec/jwk/decode_with_jwk_spec.rb
@@ -7,11 +7,11 @@ RSpec.describe JWT do
     let(:public_jwks) { { keys: [jwk.export, { kid: 'not_the_correct_one' }] } }
     let(:token_payload) { {'data' => 'something'} }
     let(:token_headers) { { kid: jwk.kid } }
-    let(:signed_token)  { described_class.encode(token_payload, jwk.keypair, 'RS512', token_headers) }
+    let(:signed_token)  { JWT.encode(payload: token_payload, signer: JWT::Signer.new(jwk.keypair, 'RS512'), header_fields: token_headers) }
 
     context 'when JWK features are used manually' do
       it 'is able to decode the token' do
-        payload, _header = described_class.decode(signed_token, nil, true, { algorithms: ['RS512'] }) do |header, _payload|
+        payload, _header = JWT.decode(signed_token, nil, true, { algorithms: ['RS512'] }) do |header, _payload|
           JWT::JWK.import(public_jwks[:keys].find { |key| key[:kid] == header['kid'] }).keypair
         end
         expect(payload).to eq(token_payload)
@@ -21,7 +21,7 @@ RSpec.describe JWT do
     context 'when jwk keys are given as an array' do
       context 'and kid is in the set' do
         it 'is able to decode the token' do
-          payload, _header = described_class.decode(signed_token, nil, true, { algorithms: ['RS512'], jwks: public_jwks})
+          payload, _header = JWT.decode(signed_token, nil, true, { algorithms: ['RS512'], jwks: public_jwks})
           expect(payload).to eq(token_payload)
         end
       end
@@ -31,7 +31,7 @@ RSpec.describe JWT do
           public_jwks[:keys].first[:kid] = 'NOT_A_MATCH'
         end
         it 'raises an exception' do
-          expect { described_class.decode(signed_token, nil, true, { algorithms: ['RS512'], jwks: public_jwks}) }.to raise_error(
+          expect { JWT.decode(signed_token, nil, true, { algorithms: ['RS512'], jwks: public_jwks}) }.to raise_error(
             JWT::DecodeError, /Could not find public key for kid .*/
           )
         end
@@ -40,7 +40,7 @@ RSpec.describe JWT do
       context 'no keys are found in the set' do
         let(:public_jwks) { {keys: []} }
         it 'raises an exception' do
-          expect { described_class.decode(signed_token, nil, true, { algorithms: ['RS512'], jwks: public_jwks}) }.to raise_error(
+          expect { JWT.decode(signed_token, nil, true, { algorithms: ['RS512'], jwks: public_jwks}) }.to raise_error(
             JWT::DecodeError, /No keys found in jwks/
           )
         end
@@ -49,7 +49,7 @@ RSpec.describe JWT do
       context 'token does not know the kid' do
         let(:token_headers) { {} }
         it 'raises an exception' do
-          expect { described_class.decode(signed_token, nil, true, { algorithms: ['RS512'], jwks: public_jwks}) }.to raise_error(
+          expect { JWT.decode(signed_token, nil, true, { algorithms: ['RS512'], jwks: public_jwks}) }.to raise_error(
             JWT::DecodeError, 'No key id (kid) found from token headers'
           )
         end
@@ -58,7 +58,7 @@ RSpec.describe JWT do
 
     context 'when jwk keys are loaded using a proc/lambda' do
       it 'decodes the token' do
-        payload, _header = described_class.decode(signed_token, nil, true, { algorithms: ['RS512'], jwks: lambda { |_opts| public_jwks }})
+        payload, _header = JWT.decode(signed_token, nil, true, { algorithms: ['RS512'], jwks: lambda { |_opts| public_jwks }})
         expect(payload).to eq(token_payload)
       end
     end
@@ -66,7 +66,7 @@ RSpec.describe JWT do
     context 'when jwk keys are rotated' do
       it 'decodes the token' do
         key_loader = ->(options) { options[:invalidate] ? public_jwks : { keys: [] } }
-        payload, _header = described_class.decode(signed_token, nil, true, { algorithms: ['RS512'], jwks: key_loader})
+        payload, _header = JWT.decode(signed_token, nil, true, { algorithms: ['RS512'], jwks: key_loader})
         expect(payload).to eq(token_payload)
       end
     end
@@ -74,7 +74,7 @@ RSpec.describe JWT do
     context 'when jwk keys are loaded from JSON with string keys' do
       it 'decodes the token' do
         key_loader = ->(_options) { JSON.parse(JSON.generate(public_jwks)) }
-        payload, _header = described_class.decode(signed_token, nil, true, { algorithms: ['RS512'], jwks: key_loader})
+        payload, _header = JWT.decode(signed_token, nil, true, { algorithms: ['RS512'], jwks: key_loader})
         expect(payload).to eq(token_payload)
       end
     end
@@ -87,10 +87,10 @@ RSpec.describe JWT do
       let(:jwks)               { { keys: [hmac_jwk.export(include_private: true), rsa_jwk.export, ec_jwk_secp384r1.export, ec_jwk_secp521r1.export] } }
 
       context 'when RSA key is pointed to as HMAC secret' do
-        let(:signed_token) { described_class.encode({'foo' => 'bar'}, 'is not really relevant in the scenario', 'HS256', { kid: rsa_jwk.kid }) }
+        let(:signed_token) { JWT.encode(payload: {'foo' => 'bar'}, signer: JWT::Signer.new('is not really relevant in the scenario', 'HS256'), header_fields: { kid: rsa_jwk.kid }) }
 
         it 'fails in some way' do
-          expect { described_class.decode(signed_token, nil, true, algorithms: ['HS256'], jwks: jwks) }.to(
+          expect { JWT.decode(signed_token, nil, true, algorithms: ['HS256'], jwks: jwks) }.to(
             raise_error do |e|
               if defined?(RbNaCl)
                 expect(e).to be_a(NoMethodError)
@@ -105,10 +105,10 @@ RSpec.describe JWT do
       end
 
       context 'when EC key is pointed to as HMAC secret' do
-        let(:signed_token) { described_class.encode({'foo' => 'bar'}, 'is not really relevant in the scenario', 'HS256', { kid: ec_jwk_secp384r1.kid }) }
+        let(:signed_token) { JWT.encode(payload: {'foo' => 'bar'}, signer: JWT::Signer.new('is not really relevant in the scenario', 'HS256'), header_fields: { kid: ec_jwk_secp384r1.kid }) }
 
         it 'fails in some way' do
-          expect { described_class.decode(signed_token, nil, true, algorithms: ['HS256'], jwks: jwks) }.to(
+          expect { JWT.decode(signed_token, nil, true, algorithms: ['HS256'], jwks: jwks) }.to(
             raise_error do |e|
               if defined?(RbNaCl)
                 expect(e).to be_a(NoMethodError)
@@ -123,40 +123,40 @@ RSpec.describe JWT do
       end
 
       context 'when EC key is pointed to as RSA public key' do
-        let(:signed_token) { described_class.encode({'foo' => 'bar'}, rsa_jwk.keypair, 'RS512', { kid: ec_jwk_secp384r1.kid }) }
+        let(:signed_token) { JWT.encode(payload: {'foo' => 'bar'}, signer: JWT::Signer.new(rsa_jwk.keypair, 'RS512'), header_fields: { kid: ec_jwk_secp384r1.kid }) }
 
         it 'fails in some way' do
-          expect { described_class.decode(signed_token, nil, true, algorithms: ['RS512'], jwks: jwks) }.to(
+          expect { JWT.decode(signed_token, nil, true, algorithms: ['RS512'], jwks: jwks) }.to(
             raise_error(JWT::VerificationError, 'Signature verification raised')
           )
         end
       end
 
       context 'when HMAC secret is pointed to as RSA public key' do
-        let(:signed_token) { described_class.encode({'foo' => 'bar'}, rsa_jwk.keypair, 'RS512', { kid: hmac_jwk.kid }) }
+        let(:signed_token) { JWT.encode(payload: {'foo' => 'bar'}, signer: JWT::Signer.new(rsa_jwk.keypair, 'RS512'), header_fields: { kid: hmac_jwk.kid }) }
 
         it 'fails in some way' do
-          expect { described_class.decode(signed_token, nil, true, algorithms: ['RS512'], jwks: jwks) }.to(
+          expect { JWT.decode(signed_token, nil, true, algorithms: ['RS512'], jwks: jwks) }.to(
             raise_error(NoMethodError, /undefined method `verify' for "secret":String/)
           )
         end
       end
 
       context 'when HMAC secret is pointed to as EC public key' do
-        let(:signed_token) { described_class.encode({'foo' => 'bar'}, ec_jwk_secp384r1.keypair, 'ES384', { kid: hmac_jwk.kid }) }
+        let(:signed_token) { JWT.encode(payload: {'foo' => 'bar'}, signer: JWT::Signer.new(ec_jwk_secp384r1.keypair, 'ES384'), header_fields: { kid: hmac_jwk.kid }) }
 
         it 'fails in some way' do
-          expect { described_class.decode(signed_token, nil, true, algorithms: ['ES384'], jwks: jwks) }.to(
+          expect { JWT.decode(signed_token, nil, true, algorithms: ['ES384'], jwks: jwks) }.to(
             raise_error(NoMethodError, /undefined method `group' for "secret":String/)
           )
         end
       end
 
       context 'when ES384 key is pointed to as ES512 key' do
-        let(:signed_token) { described_class.encode({'foo' => 'bar'}, ec_jwk_secp384r1.keypair, 'ES512', { kid: ec_jwk_secp521r1.kid }) }
+        let(:signed_token) { JWT.encode(payload: {'foo' => 'bar'}, signer: JWT::Signer.new(ec_jwk_secp384r1.keypair, 'ES512'), header_fields: { kid: ec_jwk_secp521r1.kid }) }
 
         it 'fails in some way' do
-          expect { described_class.decode(signed_token, nil, true, algorithms: ['ES512'], jwks: jwks) }.to(
+          expect { JWT.decode(signed_token, nil, true, algorithms: ['ES512'], jwks: jwks) }.to(
             raise_error(JWT::IncorrectAlgorithm, 'payload algorithm is ES512 but ES384 signing key was provided')
           )
         end

--- a/spec/x5c_key_finder_spec.rb
+++ b/spec/x5c_key_finder_spec.rb
@@ -53,7 +53,7 @@ describe JWT::X5cKeyFinder do
 
   context '::JWT.decode' do
     let(:token_payload) { { 'data' => 'something' } }
-    let(:encoded_token) { JWT.encode(token_payload, leaf_key, 'RS256', { 'x5c' => x5c_header }) }
+    let(:encoded_token) { JWT.encode(payload: token_payload, signer: JWT::Signer.new(leaf_key, 'RS256'), header_fields: { 'x5c' => x5c_header }) }
     let(:decoded_payload) do
       JWT.decode(encoded_token, nil, true, algorithms: ['RS256'], x5c: { root_certificates: [root_certificate], crls: [crl]}).first
     end


### PR DESCRIPTION
Change the signature of `encode` to accept a signer instead of a key and
an algorithm.  This would allow for an easier inegration with something
like Amazon KMS to handle signing the token.